### PR TITLE
修复存入数据库内容与标题颠倒的Bug

### DIFF
--- a/src/main/java/com/github/hcsp/News.java
+++ b/src/main/java/com/github/hcsp/News.java
@@ -13,10 +13,10 @@ public class News {
     public News() {
     }
 
-    public News(String url, String content, String title) {
+    public News(String url, String title, String content) {
         this.url = url;
-        this.content = content;
         this.title = title;
+        this.content = content;
     }
 
     public News(News old) {


### PR DESCRIPTION
修复存入数据库内容与标题颠倒的Bug
问题发生在News构造器中的参数
```
 public News(String url, String content, String title) {
        this.url = url;
        this.content = content;
        this.title = title;
    }
```
修改为
```
 public News(String url, String title, String content){
        this.url = url;
        this.title = title;
        this.content = content;
}
```